### PR TITLE
Fixed issue with upgrade to Clojure 1.10

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.10.0"]
-                 [org.clojure/clojure-contrib "1.2.0"]
+                 [org.clojure/math.numeric-tower "0.0.4"]
                  [incanter "1.5.1"]]
   :main clojure-katas.core
   :profiles {:answers {:source-paths ["src-answers"]}}

--- a/src-answers/clojure_katas/fixed_point.clj
+++ b/src-answers/clojure_katas/fixed_point.clj
@@ -1,11 +1,11 @@
 (ns clojure-katas.fixed-point
   (:require [clojure-katas.core :as core]
-            [clojure.contrib.math :as math]))
+            [clojure.math.numeric-tower :as math]))
 
 (defn fixed-point
   [f x]
   (let [tol 0.0001
-    close-enough? (fn [v1 v2] ( < (math/abs (- v1 v2)) tol))]
+    close-enough? (fn [v1 v2] ( < (Math/abs (- v1 v2)) tol))]
     (loop [v1 x
       v2 (f x)]
       (if (close-enough? v1 v2)

--- a/src/clojure_katas/fixed_point.clj
+++ b/src/clojure_katas/fixed_point.clj
@@ -1,6 +1,6 @@
 (ns clojure-katas.fixed-point
   (:require [clojure-katas.core :as core]
-            [clojure.contrib.math :as math]))
+    [clojure.math.numeric-tower :as math]))
 
 (core/defproblem fixed-point
     "A number x is called a fixed point of a function f

--- a/test/clojure_katas/fixed_point_test.clj
+++ b/test/clojure_katas/fixed_point_test.clj
@@ -1,7 +1,7 @@
 (ns clojure-katas.fixed-point-test
   (:use clojure.test
         clojure-katas.fixed-point)
-  (:require [clojure.contrib.math :as math]))
+  (:require [clojure.math.numeric-tower :as math]))
 
 (deftest fixed-point-test
   (testing "approximate val using fixed-point"

--- a/test/clojure_katas/test_runner.clj
+++ b/test/clojure_katas/test_runner.clj
@@ -26,13 +26,16 @@
         (and (try
                (require ns)
                true ; continue
-               (catch clojure.lang.ExceptionInfo e
-                 (if (contains? (ex-data e) :symbol)
-                   (let [sym (-> e ex-data :symbol)]
-                     (println "Current kata to tackle: " sym)
-                     false ; don't continue
-                     )
-                   (throw e))))
+               (catch Exception e
+                 (let [mapped-ex (Throwable->map e)]
+                  (if (and 
+                          (= "Unimplemented problem" (:cause mapped-ex))
+                          (contains? (:data mapped-ex) :symbol))
+                    (let [sym (-> mapped-ex :data :symbol)]
+                      (println "Current kata to tackle: " sym)
+                      false ; don't continue
+                      )
+                    (throw e)))))
              (let [{:keys [error fail]} (t/run-tests ns)]
                (= 0 error fail))
              (recur more))))))


### PR DESCRIPTION
* Change the Number library from contrib(which is dead) to clojure.math.numeric-tower for the `lein kata-answers` to work
* changed how to handle the errors from the defproblem macro to get `lein kata-run` to work properly